### PR TITLE
Add Puppetserver report purge feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Only RHEL 9 and compatibles are supported currently.
 ## puppetserver_stack
 
 This is the main entrypoint for this collection. It installs and configures
-Puppetserver, PuppetDB and Puppet Agent. Variables you might want to set are:
+Puppetserver, PuppetDB and Puppet Agent. A cronjob is also installed to ensure
+stale Puppet reports dont persist. Variables you might want to set are:
 
     puppet_puppetserver_manage_firewall: true
     puppet_puppetserver_zone_name: public
+    puppet_puppetserver_report_purge_maxdays: 7
 
 ## r10k
 

--- a/roles/puppetserver/defaults/main.yml
+++ b/roles/puppetserver/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 puppet_puppetserver_manage_firewall: true
+puppet_puppetserver_report_purge_maxdays: 7

--- a/roles/puppetserver/tasks/main.yml
+++ b/roles/puppetserver/tasks/main.yml
@@ -15,3 +15,7 @@
 - name: Set up puppetserver firewall
   ansible.builtin.import_tasks:
     file: firewall.yml
+
+- name: Set up puppetserver report purge cron
+  ansible.builtin.import_tasks:
+    file: report_purge.yml

--- a/roles/puppetserver/tasks/report_purge.yml
+++ b/roles/puppetserver/tasks/report_purge.yml
@@ -1,0 +1,16 @@
+---
+- name: Validate parameters
+  ansible.builtin.assert:
+    that:
+      - puppet_puppetserver_report_purge_maxdays is number
+      - puppet_puppetserver_report_purge_maxdays > 0
+  when: puppet_puppetserver_report_purge_maxdays
+
+
+- name: Ensure cron exists for stale report purging
+  ansible.builtin.cron:
+    name: "Purge Stale Puppetserver Reports"
+    minute: "0"
+    hour: "2"
+    user: "root"
+    job: "/usr/bin/find /opt/puppetlabs/server/data/puppetserver/reports/ -type f -mtime +{{puppet_puppetserver_report_purge_maxdays}} -delete"


### PR DESCRIPTION
This will ensure a cronjob exists to delete old reports that are stale and taking up space.